### PR TITLE
Refactor: links of godwoken repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .docusaurus
 .cache-loader
 
+# Editors
+.idea
+
 # Misc
 .DS_Store
 .env.local

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -65,7 +65,7 @@ For more information on the CKB RPC, refer to [CKB Wiki](https://github.com/nerv
 |fee          |The transaction fee, this is a CKB transaction and the default rate is 0.0001 CKB.|
 |godwoken-rpc-url          |The RPC address of Godwoken, by default http://127.0.0.1:8119/|
 |privkey-path          |A file written with the private key (hex string) which is used to pay the deposit fee.|
-|scripts-deployment-path          |The JSON file path of the [script's deployment results](https://github.com/nervosnetwork/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json).|
+|scripts-deployment-path          |The JSON file path of the [script's deployment results](https://github.com/godwokenrises/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json).|
 
 ---
 
@@ -125,14 +125,14 @@ For more information on `Godwoken RPC`, refer to [Godwoken Public Network](/#god
 |godwoken-rpc-url             |The RPC address of Godwoken, by default http://127.0.0.1:8119/|
 |owner-ckb-address             |The CKB address of the recipient.|
 |privkey-path             |A file written with the private key (hex string) which is used to pay the deposit fee.|
-|scripts-deployment-path             |The JSON file path of the [script's deployment results](https://github.com/nervosnetwork/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json)|
+|scripts-deployment-path             |The JSON file path of the [script's deployment results](https://github.com/godwokenrises/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json)|
 |sudt-script-hash             |The script hash of sUDT on layer 1, defaults to 0x0000000000000000000000000000000000000000000000000000, indicating only CKB is redeemed (amount left unfilled or filled with 0).|
 
 ## **Unlocking** the Funds to Complete Withdrawal Process
 
 Withdrawing funds from Godwoken is a **two-step** process. Step one initiates the withdrawal and step two releases the funds. Godwoken uses an optimistic rollup architecture that permits only one honest node in the network. All this provides a very secure foundation for Layer 2, but comes at the cost of a **5-day** 'challenge period' when exiting from Layer 2. This is a period where the Layer 2 network operator gets time to examine and flag up any potential problems with malicious transactions and roll back if necessary. The five-day challenge period will begin once the withdrawal process has commenced. The five-day time interval is a bit long but necessary. 
 
-To `unlock` the withdrawal cells to normal ckb cells and to perform common Layer2 actions, the [`account-cli tool`](https://github.com/nervosnetwork/godwoken-examples/tree/develop/packages/tools) will be applied. 
+To `unlock` the withdrawal cells to normal ckb cells and to perform common Layer2 actions, the [`account-cli tool`](https://github.com/godwokenrises/godwoken-examples/tree/develop/packages/tools) will be applied. 
 
 Execute the `account-cli tool` unlock command:
 

--- a/docs/comparisonEVM.md
+++ b/docs/comparisonEVM.md
@@ -15,7 +15,7 @@ The maximum EVM revision supported is `EVMC_BERLIN`.
 
 ## pCKB
 
-Godwoken v1 introduced a new concept, [**pCKB**](https://github.com/nervosnetwork/godwoken/blob/develop/docs/life_of_a_polyjuice_transaction.md#pckb).
+Godwoken v1 introduced a new concept, [**pCKB**](https://github.com/godwokenrises/godwoken/blob/develop/docs/life_of_a_polyjuice_transaction.md#pckb).
 
 In Ethereum, the gas for each smart contract is derived by calculation. And the transaction fee is then calculated by multiplying the gas with the specified gas price. In Godwoken, **pCKB** is the unit for calculating transaction fees. In other words, the gas price in Ethereum is calculated as ETH/gas (in wei, i.e. 1e-18 ether), and the gas price in Godwoken is calculated as pCKB/gas. When executing a transaction, Godwoken will deduct the transaction fee by using the layer2 [sUDT](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0025-simple-udt/0025-simple-udt.md) type which is represented by **pCKB**.
 
@@ -29,11 +29,11 @@ Polyjuice only provides [contract accounts](https://ethereum.org/en/glossary/#c
 
 Ethereum processes ERC20 tokens differently from native ETH tokens, which is the reason wETH was invented. And, Godwoken conceals this difference:
 
-All tokens on Godwoken are represented as Layer 2 sUDT types whether using native CKB or any sUDT token type. Polyjuice proceeds from this Layer 2 sUDT [contract](https://github.com/nervosnetwork/godwoken-polyjuice/blob/b9c3ad4/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol) and ensures that all tokens on Godwoken are ERC20 compliant, regardless if supported by native CKB or sUDT. That is to say, it is unnecessary to distinguish between native tokens and ERC20 tokens. All that has to be handled is the same ERC20 interface for all the different tokens.
+All tokens on Godwoken are represented as Layer 2 sUDT types whether using native CKB or any sUDT token type. Polyjuice proceeds from this Layer 2 sUDT [contract](https://github.com/godwokenrises/godwoken-polyjuice/blob/b9c3ad4/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol) and ensures that all tokens on Godwoken are ERC20 compliant, regardless if supported by native CKB or sUDT. That is to say, it is unnecessary to distinguish between native tokens and ERC20 tokens. All that has to be handled is the same ERC20 interface for all the different tokens.
 
 ## Transaction Structure
 
-A Polyjuice transaction is essentially a Godwoken transaction. Ethereum transactions will be converted to the Godwoken [RawL2Transaction](https://github.com/nervosnetwork/godwoken/blob/v1.0.0-rc1/crates/types/schemas/godwoken.mol#L69-L74) type when being sent, and will be automatically processed by [Godwoken Web3](https://github.com/nervosnetwork/godwoken-web3/tree/v1.0.0-rc1).
+A Polyjuice transaction is essentially a Godwoken transaction. Ethereum transactions will be converted to the Godwoken [RawL2Transaction](https://github.com/godwokenrises/godwoken/blob/v1.0.0-rc1/crates/types/schemas/godwoken.mol#L69-L74) type when being sent, and will be automatically processed by [Godwoken Web3](https://github.com/godwokenrises/godwoken-web3/tree/v1.0.0-rc1).
 
 ## Behavioral differences of some opcodes
 
@@ -46,11 +46,11 @@ A Polyjuice transaction is essentially a Godwoken transaction. Ethereum transact
 ## Others
 
 - Transaction context
-    - `chain_id` is defined in Godwoken [RollupConfig#chain_id](https://github.com/nervosnetwork/godwoken/blob/a099f2010b212355f5504a8d464b6b70d29640a5/crates/types/schemas/godwoken.mol#L64).
+    - `chain_id` is defined in Godwoken [RollupConfig#chain_id](https://github.com/godwokenrises/godwoken/blob/a099f2010b212355f5504a8d464b6b70d29640a5/crates/types/schemas/godwoken.mol#L64).
     - the block difficulty is always `2500000000000000`
     - the gas limit  is 12500000 per block, but it is not a transaction-level limit. Any transaction can reach the gas limit
-    - the size limit for contract's return data is `[25600B](https://github.com/nervosnetwork/godwoken-scripts/blob/31293d1/c/gw_def.h#L21-L22)`
-    - the size limit for contract's storage is `[25600B](https://github.com/nervosnetwork/godwoken-scripts/blob/31293d1/c/gw_def.h#L21-L22)`
+    - the size limit for contract's return data is `[25600B](https://github.com/godwokenrises/godwoken-scripts/blob/31293d1/c/gw_def.h#L21-L22)`
+    - the size limit for contract's storage is `[25600B](https://github.com/godwokenrises/godwoken-scripts/blob/31293d1/c/gw_def.h#L21-L22)`
   
 - `transaction.to` MUST be a Contract Address
     
@@ -60,4 +60,4 @@ A Polyjuice transaction is essentially a Godwoken transaction. Ethereum transact
 - The `transfer value` can not exceed uint128:MAX
 - Pre-compiled contract
     - `bn256_pairing` is not yet supported because of the high cycle cost (WIP)
-    - [addition pre-compiled contracts](https://github.com/nervosnetwork/godwoken-polyjuice/blob/compatibility-breaking-changes/docs/Addition-Features.md)
+    - [addition pre-compiled contracts](https://github.com/godwokenrises/godwoken-polyjuice/blob/compatibility-breaking-changes/docs/Addition-Features.md)

--- a/docs/deployEthDapp.md
+++ b/docs/deployEthDapp.md
@@ -20,7 +20,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 Godwoken provides a web3 RPC compatible layer.
 
-For more information, see [Ethereum RPC (web3 RPC)](https://github.com/nervosnetwork/godwoken-web3).
+For more information, see [Ethereum RPC (web3 RPC)](https://github.com/godwokenrises/godwoken-web3).
 
 ## An Example of Deploying an Ethereum DApp to Godwoken by Godwoken-Kicker
 

--- a/docs/deployLocalNetwork.md
+++ b/docs/deployLocalNetwork.md
@@ -118,7 +118,7 @@ Creating docker_godwoken_run ... done
 ```
 
 :::note
- Note that the accounts are defined in <a href="https://github.com/nervosnetwork/godwoken-tests/blob/develop/contracts/hardhat.config.js">contract/hardhat.config.js</a>.
+ Note that the accounts are defined in <a href="https://github.com/godwokenrises/godwoken-tests/blob/develop/contracts/hardhat.config.js">contract/hardhat.config.js</a>.
 
 :::
 
@@ -127,7 +127,7 @@ Creating docker_godwoken_run ... done
 <li><p>Run Godwoken-test cases with <a href="https://hardhat.org/">Hardhat</a>.</p>
 
 ```bash
-$ git clone https://github.com/nervosnetwork/godwoken-tests
+$ git clone https://github.com/godwokenrises/godwoken-tests
 $ cd godwoken-tests
 $ cd contracts
 $ npm install
@@ -476,7 +476,7 @@ rm -rf docker/manual-artifacts
 
   ```bash
 MANUAL_BUILD_GODWOKEN=true \
-GODWOKEN_GIT_URL=ssh://git@github.com/nervosnetwork/godwoken \
+GODWOKEN_GIT_URL=ssh://git@github.com/godwokenrises/godwoken \
 GODWOKEN_GIT_CHECKOUT=compatibility-breaking-changes \
 ```
 <p>Use <code>./kicker manual-build</code>to build the binary. Or, users can build on their own, just make sure that the binary is placed in <code>docker/manual-artifacts/</code>.</p>
@@ -509,6 +509,6 @@ MANUAL_BUILD_GODWOKEN=true ./kicker start godwoken # Starts only a single godwok
 </TabItem>
 </Tabs>
 
-For more details on manual-build mode of Godwoken-kicker, refer to ][manual-build mode](https://github.com/RetricSu/godwoken-kicker/blob/compatibility-changes/docs/manual-build.md), and [the example of a one-click launch readonly node](https://github.com/nervosnetwork/godwoken-info/tree/info/testnet_v1).
+For more details on manual-build mode of Godwoken-kicker, refer to ][manual-build mode](https://github.com/RetricSu/godwoken-kicker/blob/compatibility-changes/docs/manual-build.md), and [the example of a one-click launch readonly node](https://github.com/godwokenrises/godwoken-info/tree/info/testnet_v1).
 
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -152,11 +152,11 @@ MANUAL_BUILD_POLYJUICE=false
 
 ```title="/docker/.build.mode.env"
 ####[packages]
-GODWOKEN_GIT_URL=https://github.com/nervosnetwork/godwoken.git
+GODWOKEN_GIT_URL=https://github.com/godwokenrises/godwoken.git
 GODWOKEN_GIT_CHECKOUT=master
 POLYMAN_GIT_URL=https://github.com/RetricSu/godwoken-polyman.git
 POLYMAN_GIT_CHECKOUT=master
-WEB3_GIT_URL=https://github.com/nervosnetwork/godwoken-web3.git
+WEB3_GIT_URL=https://github.com/godwokenrises/godwoken-web3.git
 WEB3_GIT_CHECKOUT=main
 ...
 ```
@@ -356,7 +356,7 @@ The current user must have permissions to run ckb-cli, Capsule, Moleculec and do
    Open a new terminal window and run the following command to clone the Godwoken source:
 
    ```bash
-   $ git clone --recursive https://github.com/nervosnetwork/godwoken
+   $ git clone --recursive https://github.com/godwokenrises/godwoken
    ```
 
 4. Deploy an SUDT script to the chain.
@@ -414,8 +414,8 @@ The current user must have permissions to run ckb-cli, Capsule, Moleculec and do
          {
              "prebuild_image": "nervos/godwoken-prebuilds:v0.6.9-rc1",
              "repos": {
-                 "godwoken_scripts": "https://github.com/nervosnetwork/godwoken-scripts#master",
-                 "godwoken_polyjuice": "https://github.com/nervosnetwork/godwoken-polyjuice#main",
+                 "godwoken_scripts": "https://github.com/godwokenrises/godwoken-scripts#master",
+                 "godwoken_polyjuice": "https://github.com/godwokenrises/godwoken-polyjuice#main",
                  "clerkb": "https://github.com/nervosnetwork/clerkb#v0.4.0"
              }
          } 
@@ -551,10 +551,10 @@ The current user must have permissions to run ckb-cli, Capsule, Moleculec and do
 
 9. Set up Polyjuice.
 
-   Clone the source of godwoken-examples. For more information, see [godwoken-examples](https://github.com/nervosnetwork/godwoken-examples).
+   Clone the source of godwoken-examples. For more information, see [godwoken-examples](https://github.com/godwokenrises/godwoken-examples).
 
    ```bash
-   $ git clone --recursive https://github.com/nervosnetwork/godwoken-examples
+   $ git clone --recursive https://github.com/godwokenrises/godwoken-examples
    ```
 
    Then, create an account on Polyjuice. It will take some time to build index for the first time. 
@@ -581,10 +581,10 @@ The current user must have permissions to run ckb-cli, Capsule, Moleculec and do
           $ docker run --name postgres -e POSTGRES_USER=user -e POSTGRES_DB=godwoken -e POSTGRES_PASSWORD=mypassword -d -p 5432:5432 postgres
           ```
 
-       2. Clone the source of [godwoken-web3](https://github.com/nervosnetwork/godwoken-web3).
+       2. Clone the source of [godwoken-web3](https://github.com/godwokenrises/godwoken-web3).
 
           ```shell
-          $ git clone https://github.com/nervosnetwork/godwoken-web3
+          $ git clone https://github.com/godwokenrises/godwoken-web3
           ```
 
        3. Prepare the `.env` file under `/godwoken-web3/packages/api-server`.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -27,7 +27,7 @@ The knowledge of Ethereum is a prerequisite for using this guide.
 Godwoken V1 is still under development and targets 100% EVM compatibility. Having the best compatibility is the objective of designing and building Godwoken/Polyjuice:
 
 - The EVM being used in Godwoken/Polyjuice should be 100% compatible with the latest forked version of Ethereum.
-- Godwoken/Polyjuice should be 100% compatible with Ethereum over the Web3 interfaces by using the [Web3 layer](https://github.com/nervosnetwork/godwoken-web3).
+- Godwoken/Polyjuice should be 100% compatible with Ethereum over the Web3 interfaces by using the [Web3 layer](https://github.com/godwokenrises/godwoken-web3).
 
 Given the wide architechtural and design differences between Godwoken/Polyjuice and Ethereum, several discrepancies inevitably exsit. 
 
@@ -35,7 +35,7 @@ Given the wide architechtural and design differences between Godwoken/Polyjuice 
 
 It is mandatory to create an account on a Godwoken chain in order to use Polyjuice. Two ways to create a layer 2 account:
 - Make a deposit to Godwoken at layer 1;
-- Call the Godwoken built-in `[meta_contract](https://github.com/nervosnetwork/godwoken-scripts/blob/86b299f/c/contracts/meta_contract.c)` and create an account at layer 2.
+- Call the Godwoken built-in `[meta_contract](https://github.com/godwokenrises/godwoken-scripts/blob/86b299f/c/contracts/meta_contract.c)` and create an account at layer 2.
 
 ## pCKB
 

--- a/docs/keyConcepts.md
+++ b/docs/keyConcepts.md
@@ -204,7 +204,7 @@ CKB faucet uses the same key as CKB miner. When executing `./kicker deposit`, CK
 
 ## [Deployer of Rollup Genesis Cell](https://github.com/RetricSu/godwoken-kicker/blob/compatibility-changes/accounts/godwoken-block-producer.key)
 
-This key is used when the deployer of rollup genesis cell on layer 1 deploys the rollup genesis cell. When setting up the rollup genesis cell on layer 1, `gw-tools deploy-genesis` uses `[Omnilock](https://blog.cryptape.com/omnilock-a-universal-lock-that-powers-interoperability-1)` to [record the public key](https://github.com/nervosnetwork/godwoken/blob/c18807b5cfaa961c230e15e3a381570c324db6f8/crates/tools/src/deploy_genesis.rs#L428-L448).
+This key is used when the deployer of rollup genesis cell on layer 1 deploys the rollup genesis cell. When setting up the rollup genesis cell on layer 1, `gw-tools deploy-genesis` uses `[Omnilock](https://blog.cryptape.com/omnilock-a-universal-lock-that-powers-interoperability-1)` to [record the public key](https://github.com/godwokenrises/godwoken/blob/c18807b5cfaa961c230e15e3a381570c324db6f8/crates/tools/src/deploy_genesis.rs#L428-L448).
 
 ## [Deployer of Rollup Scripts](https://github.com/RetricSu/godwoken-kicker/blob/compatibility-changes/accounts/rollup-scripts-deployer.key)
 

--- a/docs/latest/gwchangev1.6.md
+++ b/docs/latest/gwchangev1.6.md
@@ -6,29 +6,29 @@ title: Godwoken V1.6 Release Note
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
 
-Godwoken is currently updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.6. You can check the full release notes in the [Godwoken Changlog](https://github.com/nervosnetwork/godwoken/blob/develop/CHANGELOG.md).
+Godwoken is currently updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.6. You can check the full release notes in the [Godwoken Changlog](https://github.com/godwokenrises/godwoken/blob/develop/CHANGELOG.md).
 
 
 The latest update to Godwoken v1.6 includes the following changes:
 
-- feat: add to_address to polyjuice parser in [#784](https://github.com/nervosnetwork/godwoken/pull/784)
+- feat: add to_address to polyjuice parser in [#784](https://github.com/godwokenrises/godwoken/pull/784)
 
   Added `to_address` for checking and supporting native token transfers.
 
-- Support non EIP-155 tx in [#777](https://github.com/nervosnetwork/godwoken/pull/777)
+- Support non EIP-155 tx in [#777](https://github.com/godwokenrises/godwoken/pull/777)
 
   Godwoken now supports `EIP-155` transactions. Due to the reuse of the chain_id field, if we deploy a different Godwoken implementation with `chain_id = 0`, then a valid `EIP-155` transaction cannot be sent on-chain because Godwoken would assume the transaction as a non-EIP-155 transaction. With this pr, Godwoken accepts layer-2 transactions with `chain_id = 0`. 
 
-- Validate native token transfer raw tx and signature in [#788](https://github.com/nervosnetwork/godwoken/pull/788)
+- Validate native token transfer raw tx and signature in [#788](https://github.com/godwokenrises/godwoken/pull/788)
 
-  Related to Polyjuice [#173](https://github.com/nervosnetwork/godwoken-polyjuice/pull/173), see Polyjuice updates below for details. 
+  Related to Polyjuice [#173](https://github.com/godwokenrises/godwoken-polyjuice/pull/173), see Polyjuice updates below for details. 
 
 
-- refactor: remove sentry in [#780](https://github.com/nervosnetwork/godwoken/pull/780)
+- refactor: remove sentry in [#780](https://github.com/godwokenrises/godwoken/pull/780)
 
-- fix: recover sender of non EIP-155 txs in [#790](https://github.com/nervosnetwork/godwoken/pull/790)
+- fix: recover sender of non EIP-155 txs in [#790](https://github.com/godwokenrises/godwoken/pull/790)
 
-- fix(tools): Fix for withdraw cli in [#792](https://github.com/nervosnetwork/godwoken/pull/792)
+- fix(tools): Fix for withdraw cli in [#792](https://github.com/godwokenrises/godwoken/pull/792)
 
 
 ## Polyjuice
@@ -37,7 +37,7 @@ Polyjuice is an EVM-compatible executing environment built to work with the Godw
 
 Updates in the current release include:
 
-- feat: support native token transfer in [#173](https://github.com/nervosnetwork/godwoken-polyjuice/pull/173)
+- feat: support native token transfer in [#173](https://github.com/godwokenrises/godwoken-polyjuice/pull/173)
 
   A handler is added to deal with native token transfers before accessing EVM, and defined a native token transfer transaction as follows:
 
@@ -46,14 +46,14 @@ Updates in the current release include:
          - Added `to_address` to the end of the polyjuice args.
          - `to_addrress` should not be a contract.
 
-- feat: Create new account during transferring if the to_address is not registered in [#177](https://github.com/nervosnetwork/godwoken-polyjuice/pull/177)
+- feat: Create new account during transferring if the to_address is not registered in [#177](https://github.com/godwokenrises/godwoken-polyjuice/pull/177)
 
   With this pr, a new EoA account will be created during the native token transfer if `to_address` is not registered. It also fixed a test issue triggered by an update to the account recovered from godwoken.
 
-- fix: g_gas_price constant is too large for its type in [#175](https://github.com/nervosnetwork/godwoken-polyjuice/pull/175)
+- fix: g_gas_price constant is too large for its type in [#175](https://github.com/godwokenrises/godwoken-polyjuice/pull/175)
 
-- test: handle logs hash in post of ethereum tests in [#174](https://github.com/nervosnetwork/godwoken-polyjuice/pull/174)
+- test: handle logs hash in post of ethereum tests in [#174](https://github.com/godwokenrises/godwoken-polyjuice/pull/174)
 
-- test: integrate ethereum tests in [#172](https://github.com/nervosnetwork/godwoken-polyjuice/pull/172)
+- test: integrate ethereum tests in [#172](https://github.com/godwokenrises/godwoken-polyjuice/pull/172)
 
-- Fix wrong used_gas of native transfer in polyjuice_system_log in [#179](https://github.com/nervosnetwork/godwoken-polyjuice/pull/179)
+- Fix wrong used_gas of native transfer in polyjuice_system_log in [#179](https://github.com/godwokenrises/godwoken-polyjuice/pull/179)

--- a/docs/latest/web3changev1.7.md
+++ b/docs/latest/web3changev1.7.md
@@ -5,30 +5,30 @@ title: Godwoken Web3 V1.7 Release Note
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-[Godwoken Web3](https://github.com/nervosnetwork/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.7. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/nervosnetwork/godwoken-web3/releases).
+[Godwoken Web3](https://github.com/godwokenrises/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.7. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/godwokenrises/godwoken-web3/releases).
 
 The latest update to Godwoken Web3 v1.7 includes the following changes:
 
 ## Feat
 
-- Support native transfer in [#505](https://github.com/nervosnetwork/godwoken-web3/pull/505)
+- Support native transfer in [#505](https://github.com/godwokenrises/godwoken-web3/pull/505)
 
   Added support for native token transfers. 
 
-- feat: Support non eip155 tx in [#490](https://github.com/nervosnetwork/godwoken-web3/pull/490)
+- feat: Support non eip155 tx in [#490](https://github.com/godwokenrises/godwoken-web3/pull/490)
 
-- feat: add poly_getHealthStatus api and health-check script in [#497](https://github.com/nervosnetwork/godwoken-web3/pull/497)
+- feat: add poly_getHealthStatus api and health-check script in [#497](https://github.com/godwokenrises/godwoken-web3/pull/497)
 
-- feat: Restart worker if exit with error code in [#513](https://github.com/nervosnetwork/godwoken-web3/pull/513)
+- feat: Restart worker if exit with error code in [#513](https://github.com/godwokenrises/godwoken-web3/pull/513)
 
 ## Fixed
 
-- fix: declare StorageKey as HexNumber type in [#510](https://github.com/nervosnetwork/godwoken-web3/pull/510)
+- fix: declare StorageKey as HexNumber type in [#510](https://github.com/godwokenrises/godwoken-web3/pull/510)
 
-- fix: method not found in ws api in [#493](https://github.com/nervosnetwork/godwoken-web3/pull/493)
+- fix: method not found in ws api in [#493](https://github.com/godwokenrises/godwoken-web3/pull/493)
 
 ## Other
 
-- refactor: use global redis client in cacheStore in [#491](https://github.com/nervosnetwork/godwoken-web3/pull/491)
+- refactor: use global redis client in cacheStore in [#491](https://github.com/godwokenrises/godwoken-web3/pull/491)
 
-- refactor: reuse tx hash convert fn in [#489](https://github.com/nervosnetwork/godwoken-web3/pull/489)
+- refactor: reuse tx hash convert fn in [#489](https://github.com/godwokenrises/godwoken-web3/pull/489)

--- a/docs/liteGodwokenWithdraw.md
+++ b/docs/liteGodwokenWithdraw.md
@@ -13,7 +13,7 @@ Visit [MetaMask](https://metamask.io/) to download the wallet. For more informat
 
 1. Add the Godwoken Network manually to the MetaMask wallet.  
 
- Godwoken v1 is currently in active development. For more information on Godwoken public networks, see [godwoken](https://github.com/nervosnetwork/godwoken-info).
+ Godwoken v1 is currently in active development. For more information on Godwoken public networks, see [godwoken](https://github.com/godwokenrises/godwoken-info).
 
 
 2. Bridge Your Own Assets
@@ -50,9 +50,9 @@ In the [Godwoken Bridge Withdrawal UI](https://testnet.bridge.godwoken.io/#/v0),
 
 |Resource|Link|
 |---|---|
-|Godwoken Docs| https://github.com/nervosnetwork/godwoken/blob/develop/docs/RPC.md#method-gw_submit_withdrawal_request|
+|Godwoken Docs| https://github.com/godwokenrises/godwoken/blob/develop/docs/RPC.md#method-gw_submit_withdrawal_request|
 |Godwoken Demos| https://github.com/classicalliu/gw-demos|
-|Godwoken testnet config| https://github.com/nervosnetwork/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json|
+|Godwoken testnet config| https://github.com/godwokenrises/godwoken-public/blob/master/testnet/config/scripts-deploy-result.json|
 |Polyjuice Provider| https://github.com/nervosnetwork/polyjuice-provider|
-|Godwoken Web3| https://github.com/nervosnetwork/godwoken-web3#godwoken-web3-api|
+|Godwoken Web3| https://github.com/godwokenrises/godwoken-web3#godwoken-web3-api|
 |Lumos Documentation| https://github.com/nervosnetwork/lumos| 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,13 +8,13 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 With the vision to enable interoperability across the blockchain ecosystem through a multi-chain solution, Godwoken is an impactful move towards this objective for Nervos Network.
 
-[Godwoken](https://github.com/nervosnetwork/godwoken) is a layer 2 optimistic rollup solution and an EVM-compatible layer that builds on top of Nervos Layer 1, which is also known as CKB. Godwoken comprises two key component: Godwoken optimistic rollup framework and the Polyjuice EVM-compatible framework. Both Godwoken and Polyjuice together forge a scalable EVM-compatible solution for Nervos, generally known as **Godwoken**.
+[Godwoken](https://github.com/godwokenrises/godwoken) is a layer 2 optimistic rollup solution and an EVM-compatible layer that builds on top of Nervos Layer 1, which is also known as CKB. Godwoken comprises two key component: Godwoken optimistic rollup framework and the Polyjuice EVM-compatible framework. Both Godwoken and Polyjuice together forge a scalable EVM-compatible solution for Nervos, generally known as **Godwoken**.
 
 Godwoken emerged as a solution for dapp builders as they seek to benefit from the advantages of Ethereum, such as its establishment, good tooling, and documentation, by not being plagued by its drawbacks, such as network congestion, high gas fees, oversaturation, and scalability issues. 
 
 Powered by Godwoken, developers can choose to work with Solidity, just like on Ethereum, while enjoying extra bonuses of interoperability with other blockchains. For Ethereum developers, Godwoken is the go-to option for both universes. Developers can port their existing dapps to Nervos with ease, expanding their reach and brand awareness in a DeFi development-focused network, while benefiting from an instant transaction end result and a low fee in an Ethereum-like environment.
 
-**Polyjuice** is a backend for the Ethereum-compatible Godwoken rollup framework, provides an Ethereum-compatible layer atop Nervos CKB. Polyjuice leverages the account model and the scalability provided by Godwoken to integrate evmone as the EVM engine to run Ethereum smart contracts. More information about Polyjuice, visite [godwoken-polyjuice](https://github.com/nervosnetwork/godwoken-polyjuice).
+**Polyjuice** is a backend for the Ethereum-compatible Godwoken rollup framework, provides an Ethereum-compatible layer atop Nervos CKB. Polyjuice leverages the account model and the scalability provided by Godwoken to integrate evmone as the EVM engine to run Ethereum smart contracts. More information about Polyjuice, visite [godwoken-polyjuice](https://github.com/godwokenrises/godwoken-polyjuice).
 
 <img src={useBaseUrl("img/arch.png")}  width="40%"/>
 
@@ -28,10 +28,10 @@ To be specific, when a user creates a new account by making a deposit, an Ethere
 
 ## Godwoken Public Networks
 
-Godwoken is under active deveopment phase, for more information on Godwoken public Networks see [godwoken](https://github.com/nervosnetwork/godwoken).
+Godwoken is under active deveopment phase, for more information on Godwoken public Networks see [godwoken](https://github.com/godwokenrises/godwoken).
 
 
-Godwoken v1 network can be deployed locally with Godwoken-kicker in two ways, quick deploy and manual-build mode. For more information, refer to Github Repository [godwoken-info](https://github.com/nervosnetwork/godwoken-info/tree/info). 
+Godwoken v1 network can be deployed locally with Godwoken-kicker in two ways, quick deploy and manual-build mode. For more information, refer to Github Repository [godwoken-info](https://github.com/godwokenrises/godwoken-info/tree/info). 
 
 For an introduction to the Nervos ecosystem, an overview of various important concepts, and hands-on direct experience with the platform in preparation for deploying real-world dapps, check **[Nervos Layer 2 EVM training](https://nervos.gitbook.io/layer-2-evm/).**
 
@@ -43,7 +43,7 @@ For an introduction to the Nervos ecosystem, an overview of various important co
 | Nervos&nbsp;Layer&nbsp;2 EVM&nbsp;Training | https://nervos.gitbook.io/layer-2-evm/                       |
 | Nervos&nbsp;Document&nbsp;Website          | https://docs.nervos.org/                                     |
 | Godwoken&nbsp;Basics                       | <ul><li>[Introducing Godwoken - A missing piece of the cell model](https://talk.nervos.org/t/introducing-godwoken-a-missing-piece-of-the-cell-model/4464?_360safeparam=13594453)</li><li>[Towards CKB style Lego pieces: Polyjuice on Godwoken](https://medium.com/nervosnetwork/towards-ckb-style-lego-pieces-polyjuice-on-godwoken-cbc935d77abf)</li></ul> |
-| Source&nbsp;Code                           | https://github.com/nervosnetwork/godwoken                    |
+| Source&nbsp;Code                           | https://github.com/godwokenrises/godwoken                    |
 | Godwoken-Kicker                            | [Godwoken-Kicker: one line command to start godwoken-polyjuice chain](https://github.com/RetricSu/godwoken-kicker) |
 | Ethereum&nbsp;RPC&nbsp; (web3&nbsp;RPC)    | [Ethereum RPC (web3 RPC)](https://geth.ethereum.org/docs/rpc/server) |
 | Gitcoin&nbsp;Hackathon                     | <ul><li>[Godwoken Gitcoin Instruction](https://github.com/Kuzirashi/gw-gitcoin-instruction)</li><li>[NERVOS - BROADEN THE SPECTRUM](https://gitcoin.co/hackathon/nervos/onboard)</li></ul> |

--- a/docs/releaseNote.md
+++ b/docs/releaseNote.md
@@ -15,20 +15,20 @@ In the new version, compatibility improvements for Godwoken include:
 
 - Provide API level compatiblility. Remove the web3-provider plugin.
 - Support native ETH address in API and EVM, remove the Godwoken address concept.
-- Support Ethereum signature format and EIP-712. User can view the transaction before signing, rather than signing a random 32-byte message.[#561](https://github.com/nervosnetwork/godwoken/pull/561)
-- Fix total provisioning interface for sUDT ERC-20 proxy contracts [#560](https://github.com/nervosnetwork/godwoken/pull/560)
+- Support Ethereum signature format and EIP-712. User can view the transaction before signing, rather than signing a random 32-byte message.[#561](https://github.com/godwokenrises/godwoken/pull/561)
+- Fix total provisioning interface for sUDT ERC-20 proxy contracts [#560](https://github.com/godwokenrises/godwoken/pull/560)
 - Support interactive with Ethereum addresses that are not yet registered to Godwoken.
 - Unify layer 2 fungible token represatation as unit256.
-- Change layer 2 ckb decimal from 8 to 18, improve compatibility between metamask and native ckb. [#675](https://github.com/nervosnetwork/godwoken/pull/675)
+- Change layer 2 ckb decimal from 8 to 18, improve compatibility between metamask and native ckb. [#675](https://github.com/godwokenrises/godwoken/pull/675)
 
 Briefly, developers can use Godwoken v1 the same way they use other ethereum-compatible chains, requiring only switching the network to Godwoken. With v1, the polyjuice-provider web3 plugin was removed.
 
 ## Other improvements
 
-- Support p2p mem-pool syncing [#642](https://github.com/nervosnetwork/godwoken/pull/642), further PRs to enable fully decentralized syncing, but this PR is a good starting.
-- perf: optimize molecule usage [#640](https://github.com/nervosnetwork/godwoken/pull/640)
-- perf: use BTreeSet in FeeQueue [#641](https://github.com/nervosnetwork/godwoken/pull/641)
-- Change rollup cell's lock to omni-lock [#608](https://github.com/nervosnetwork/godwoken/pull/608). This PR enables optimistic rollup to submit larger size blocks to fix the inability of putting too much data in the witness field of a CKB transaction due to a secp256k1-lock limit.
+- Support p2p mem-pool syncing [#642](https://github.com/godwokenrises/godwoken/pull/642), further PRs to enable fully decentralized syncing, but this PR is a good starting.
+- perf: optimize molecule usage [#640](https://github.com/godwokenrises/godwoken/pull/640)
+- perf: use BTreeSet in FeeQueue [#641](https://github.com/godwokenrises/godwoken/pull/641)
+- Change rollup cell's lock to omni-lock [#608](https://github.com/godwokenrises/godwoken/pull/608). This PR enables optimistic rollup to submit larger size blocks to fix the inability of putting too much data in the witness field of a CKB transaction due to a secp256k1-lock limit.
 
 ## Godwoken internal changes
 
@@ -37,4 +37,4 @@ Briefly, developers can use Godwoken v1 the same way they use other ethereum-com
 
 v1 adds a new concept in having the Ethereum address registry stores Ethereum addresses in Godwoken. Once user deposits a new account, Godwoken will create a mapping between the Ethereum address and the account. In addition, some RPCs have been adapted to support Ethereum addresses as parameters, and some Godwoken data structures have been adapted to support the new address format.
 
-More details about Godwoken internal changes refer to: [docs/release-notes/v1-internal-CHANGES.md](https://github.com/nervosnetwork/godwoken/blob/72b6728e4315ab581282685cffe75cdbfe38670c/docs/release-notes/v1-internal-CHANGES.md).
+More details about Godwoken internal changes refer to: [docs/release-notes/v1-internal-CHANGES.md](https://github.com/godwokenrises/godwoken/blob/72b6728e4315ab581282685cffe75cdbfe38670c/docs/release-notes/v1-internal-CHANGES.md).

--- a/docs/releaseNote1.5.md
+++ b/docs/releaseNote1.5.md
@@ -4,20 +4,20 @@ title: Godwoken V1.5 Release Note
 ---
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-Godwoken is currently updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.5. You can check the full release notes in the [Godwoken Changlog](https://github.com/nervosnetwork/godwoken/blob/develop/CHANGELOG.md).
+Godwoken is currently updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.5. You can check the full release notes in the [Godwoken Changlog](https://github.com/godwokenrises/godwoken/blob/develop/CHANGELOG.md).
 
 The latest update to Godwoken v1.5 includes the following changes:
 
 #### Added
-- feat: Introduced max_cycles_limit of a Godwoken block in [#767](https://github.com/nervosnetwork/godwoken/pull/767)
+- feat: Introduced max_cycles_limit of a Godwoken block in [#767](https://github.com/godwokenrises/godwoken/pull/767)
     This PR aims to add a dynamic and configurable way to manage the number of block transactions. This PR added a new cycle limit `max_cycles_limit` to the mem block. If there are not enough cycles available in the mem pool, the transaction will be packed into the next block. If a transaction has more cycles than `max_cycles_limit`, it will be discarded.
 
-- Add RPC `get_pending_tx_hashes` in [#772](https://github.com/nervosnetwork/godwoken/pull/772)
+- Add RPC `get_pending_tx_hashes` in [#772](https://github.com/godwokenrises/godwoken/pull/772)
     This PR added the new RPC `gw_get_pending_tx_hashes` to fetch pending transaction hashes, so that developers can get the `mem_pool` transactions of Godwoken.
 
 #### Fixed
-- fix `cargo test -p gw-tests` in [#773](https://github.com/nervosnetwork/godwoken/pull/773)
+- fix `cargo test -p gw-tests` in [#773](https://github.com/godwokenrises/godwoken/pull/773)
     This PR fixed `cargo test -p gw-tests` using rand 0.8 directly instead of using rand 0.6 via secp256k1. Before, `cargo test -p gw-tests` failed to compile the `gw-tests` separately because the `rand_os` feature of rand 0.6 was unenabled.
 
-- fix submit_withdrawal_request random failure in [#774](https://github.com/nervosnetwork/godwoken/pull/774)
-- fix(mempool): pool cycles not reset on next mem block for readonly node in [#781](https://github.com/nervosnetwork/godwoken/pull/781)
+- fix submit_withdrawal_request random failure in [#774](https://github.com/godwokenrises/godwoken/pull/774)
+- fix(mempool): pool cycles not reset on next mem block for readonly node in [#781](https://github.com/godwokenrises/godwoken/pull/781)

--- a/docs/releaseNote4.md
+++ b/docs/releaseNote4.md
@@ -5,14 +5,14 @@ title: Godwoken V1.4 Release Note
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
 
-Currently, Godwoken is updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.4. You can check the full release notes in the [Godwoken Changlog](https://github.com/nervosnetwork/godwoken/blob/develop/CHANGELOG.md).
+Currently, Godwoken is updated on a regular basis to provide new features and updates. The following release notes covers the most recent changes in Godwoken v1.4. You can check the full release notes in the [Godwoken Changlog](https://github.com/godwokenrises/godwoken/blob/develop/CHANGELOG.md).
 
 The latest update to Godwoken v1.4 includes the following changes:
 
 #### Added
 
-- automatically create account for undeposited sender in [#710](https://github.com/nervosnetwork/godwoken/pull/710)
-- export and import block commands in [#754](https://github.com/nervosnetwork/godwoken/pull/754)
+- automatically create account for undeposited sender in [#710](https://github.com/godwokenrises/godwoken/pull/710)
+- export and import block commands in [#754](https://github.com/godwokenrises/godwoken/pull/754)
 
      - export-block subcommand
       ```
@@ -25,15 +25,15 @@ The latest update to Godwoken v1.4 includes the following changes:
       ```
 #### Fixed
 
-- always refresh pending deposit cells in [#753](https://github.com/nervosnetwork/godwoken/pull/753)
-- Add new argument finality-blocks to gw-tools stat-custodian-ckb … in [#757](https://github.com/nervosnetwork/godwoken/pull/757)
-- block-producer exit during bad block challenge by in [#755](https://github.com/nervosnetwork/godwoken/pull/755)
-- Update parse log in [#752](https://github.com/nervosnetwork/godwoken/pull/752)
-- fix(rpc): calculate tx signature hash using packed bytes by in [#760](https://github.com/nervosnetwork/godwoken/pull/760)
-- fix(withdrawal unlocker): unhandle tx status unknown and rejected by in [#763](https://github.com/nervosnetwork/godwoken/pull/763)
-- fix(config): removed block producer wallet config requirement for readonly node in [#768](https://github.com/nervosnetwork/godwoken/pull/768)
-- hotfix(rpc server): submit withdrawal missing data for submit_tx in [#770](https://github.com/nervosnetwork/godwoken/pull/770)
+- always refresh pending deposit cells in [#753](https://github.com/godwokenrises/godwoken/pull/753)
+- Add new argument finality-blocks to gw-tools stat-custodian-ckb … in [#757](https://github.com/godwokenrises/godwoken/pull/757)
+- block-producer exit during bad block challenge by in [#755](https://github.com/godwokenrises/godwoken/pull/755)
+- Update parse log in [#752](https://github.com/godwokenrises/godwoken/pull/752)
+- fix(rpc): calculate tx signature hash using packed bytes by in [#760](https://github.com/godwokenrises/godwoken/pull/760)
+- fix(withdrawal unlocker): unhandle tx status unknown and rejected by in [#763](https://github.com/godwokenrises/godwoken/pull/763)
+- fix(config): removed block producer wallet config requirement for readonly node in [#768](https://github.com/godwokenrises/godwoken/pull/768)
+- hotfix(rpc server): submit withdrawal missing data for submit_tx in [#770](https://github.com/godwokenrises/godwoken/pull/770)
 
 #### Others
 
-- Redirect syscall debug logs by in [#758](https://github.com/nervosnetwork/godwoken/pull/758)
+- Redirect syscall debug logs by in [#758](https://github.com/godwokenrises/godwoken/pull/758)

--- a/docs/web3Change1.5.md
+++ b/docs/web3Change1.5.md
@@ -4,39 +4,39 @@ title: Godwoken Web3 V1.5 Release Note
 ---
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-[Godwoken Web3](https://github.com/nervosnetwork/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.5. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/nervosnetwork/godwoken-web3/releases).
+[Godwoken Web3](https://github.com/godwokenrises/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.5. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/godwokenrises/godwoken-web3/releases).
 
 The latest update to Godwoken Web3 v1.5 includes the following changes:
 
 #### Added
 
-- feat: Adapt for auto create undeposited account in [#430](https://github.com/nervosnetwork/godwoken-web3/pull/430)
+- feat: Adapt for auto create undeposited account in [#430](https://github.com/godwokenrises/godwoken-web3/pull/430)
     Adapted to the automatic creation of account for undeposited sender on Godwoken.
 
-- feat: Delete dropped auto create account tx in [#445](https://github.com/nervosnetwork/godwoken-web3/pull/445)
+- feat: Delete dropped auto create account tx in [#445](https://github.com/godwokenrises/godwoken-web3/pull/445)
     Allow checks for the existence of an automatically created tx when calling RPC `eth_getTransactionByHash`, and will remove the dropped auto-create account tx.
 
 - feat: add `poly_getEthTxHashByGwTxHash` and `poly_getGwTxHashByEthTxHash` in #449
     Added two new methods, `poly_getEthTxHashByGwTxHash` and `poly_getGwTxHashByEthTxHash`, that allow the conversion between Godwoken transaction hash and Ethereum transaction hash.
 
-- feat: Add gw_is_request_in_queue in [#450](https://github.com/nervosnetwork/godwoken-web3/pull/450)
+- feat: Add gw_is_request_in_queue in [#450](https://github.com/godwokenrises/godwoken-web3/pull/450)
     This RPC method returns if the request (transaction or withdrawal) is in the fee queue. The request goes through the fee queue before being pushed to the mempool. This method is only supported on full nodes.
 
 
 #### Fixed
 
-- Fix some small bugs of filter methods (part 1) in #[427](https://github.com/nervosnetwork/godwoken-web3/pull/427)
-- Fix and refactor eth filter methods (part 3) in [#429](https://github.com/nervosnetwork/godwoken-web3/pull/429)
-- Improves the performance of `eth_getFilterChanges` by `BlockFilter`. in [#428](https://github.com/nervosnetwork/godwoken-web3/pull/428)
-- fix: correct parameter type of SQL query of `eth_getBlockTransactionCountByHash` in [#440](https://github.com/nervosnetwork/godwoken-web3/pull/440)
-- fix: Update revert error message and data in [#437](https://github.com/nervosnetwork/godwoken-web3/pull/437)
-- fix: to eoa err msg in [#441](https://github.com/nervosnetwork/godwoken-web3/pull/441)
-- fix: Add leading zeros for r & s when check auto create account tx ex… in [#457](https://github.com/nervosnetwork/godwoken-web3/pull/457)
-- fix(indexer): r & s in rlp encode should be integer rather than bytes in [#458](https://github.com/nervosnetwork/godwoken-web3/pull/458)
+- Fix some small bugs of filter methods (part 1) in #[427](https://github.com/godwokenrises/godwoken-web3/pull/427)
+- Fix and refactor eth filter methods (part 3) in [#429](https://github.com/godwokenrises/godwoken-web3/pull/429)
+- Improves the performance of `eth_getFilterChanges` by `BlockFilter`. in [#428](https://github.com/godwokenrises/godwoken-web3/pull/428)
+- fix: correct parameter type of SQL query of `eth_getBlockTransactionCountByHash` in [#440](https://github.com/godwokenrises/godwoken-web3/pull/440)
+- fix: Update revert error message and data in [#437](https://github.com/godwokenrises/godwoken-web3/pull/437)
+- fix: to eoa err msg in [#441](https://github.com/godwokenrises/godwoken-web3/pull/441)
+- fix: Add leading zeros for r & s when check auto create account tx ex… in [#457](https://github.com/godwokenrises/godwoken-web3/pull/457)
+- fix(indexer): r & s in rlp encode should be integer rather than bytes in [#458](https://github.com/godwokenrises/godwoken-web3/pull/458)
    Fix `eth_tx_hash` calculation in indexer, where the `eth_tx_hash` will be incorrect when r / s has leading zeros
 
 #### Others
 
-- chore(main): tune latest median tx to 50 in [#434](https://github.com/nervosnetwork/godwoken-web3/pull/434)
-- chore: rm minSudtFee env in [#442](https://github.com/nervosnetwork/godwoken-web3/pull/442)
-- fix(ci): upgrade baseimage to 22.04 in [#461](https://github.com/nervosnetwork/godwoken-web3/pull/461)
+- chore(main): tune latest median tx to 50 in [#434](https://github.com/godwokenrises/godwoken-web3/pull/434)
+- chore: rm minSudtFee env in [#442](https://github.com/godwokenrises/godwoken-web3/pull/442)
+- fix(ci): upgrade baseimage to 22.04 in [#461](https://github.com/godwokenrises/godwoken-web3/pull/461)

--- a/docs/web3Change1.6.md
+++ b/docs/web3Change1.6.md
@@ -4,43 +4,43 @@ title: Godwoken Web3 V1.6 Release Note
 ---
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-[Godwoken Web3](https://github.com/nervosnetwork/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.6. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/nervosnetwork/godwoken-web3/releases).
+[Godwoken Web3](https://github.com/godwokenrises/godwoken-web3) is a Ethereum-compatibility RPC layer on Godwoken. Godwoken Web3 is being continually updated. The following content covers the most recent changes in Godwoken Web3 v1.6. For the full release notes refer to [Godwoken Web3 Releases](https://github.com/godwokenrises/godwoken-web3/releases).
 
 The latest update to Godwoken Web3 v1.6 includes the following changes:
 
 #### Added
-- feat: add NewRelic instruments in [#444](https://github.com/nervosnetwork/godwoken-web3/pull/444)
+- feat: add NewRelic instruments in [#444](https://github.com/godwokenrises/godwoken-web3/pull/444)
 This PR adds NewRelic instruments for:
  - Postgres
  - Redis
  - Godwoken RPC client
  - HTTP interfaces
 
-- feat: add optional Prof rpc in [#447](https://github.com/nervosnetwork/godwoken-web3/pull/447)
-[#444](https://github.com/nervosnetwork/godwoken-web3/pull/444) PR added NewRelic to watch for perf on web3. And this PR in turn added Prof RPC module to enable quick debugging on the local environment. Only with `ENABLE_PROF_RPC=true` will allow such a module, like ckb:
+- feat: add optional Prof rpc in [#447](https://github.com/godwokenrises/godwoken-web3/pull/447)
+[#444](https://github.com/godwokenrises/godwoken-web3/pull/444) PR added NewRelic to watch for perf on web3. And this PR in turn added Prof RPC module to enable quick debugging on the local environment. Only with `ENABLE_PROF_RPC=true` will allow such a module, like ckb:
  - `prof_cpu` to debug CPU profiling
  - `prof_heap` to debug memory usage/ memory leak
 
-- feat: disallow meta contract tx, add parser tooling in [#454](https://github.com/nervosnetwork/godwoken-web3/pull/454)
-- feat: add blockSpecifer for blockParameter to support Eip1898 in [#476](https://github.com/nervosnetwork/godwoken-web3/pull/476)
-- apply rate limit to ws in [#452](https://github.com/nervosnetwork/godwoken-web3/pull/452)
-- perf(web3-indexer): Store block faster in [#414](https://github.com/nervosnetwork/godwoken-web3/pull/414)
+- feat: disallow meta contract tx, add parser tooling in [#454](https://github.com/godwokenrises/godwoken-web3/pull/454)
+- feat: add blockSpecifer for blockParameter to support Eip1898 in [#476](https://github.com/godwokenrises/godwoken-web3/pull/476)
+- apply rate limit to ws in [#452](https://github.com/godwokenrises/godwoken-web3/pull/452)
+- perf(web3-indexer): Store block faster in [#414](https://github.com/godwokenrises/godwoken-web3/pull/414)
 This PR aimed at fetching and storing transactions & logs in batch, which can be faster if the block has many transactions and logs.
 
 #### Fixed
-- fix: Get transaction from fullnode if readonly node returns null in [#469](https://github.com/nervosnetwork/godwoken-web3/pull/469)
+- fix: Get transaction from fullnode if readonly node returns null in [#469](https://github.com/godwokenrises/godwoken-web3/pull/469)
 
-- fix(indexer): dockerfile install libcurl4 in [#485](https://github.com/nervosnetwork/godwoken-web3/pull/485)
+- fix(indexer): dockerfile install libcurl4 in [#485](https://github.com/godwokenrises/godwoken-web3/pull/485)
 
-- fix: handle error for vm max cycle exceed in [#486](https://github.com/nervosnetwork/godwoken-web3/pull/486)
+- fix: handle error for vm max cycle exceed in [#486](https://github.com/godwokenrises/godwoken-web3/pull/486)
 
-- fix(indexer): Retry when tx receipt not found in [#488](https://github.com/nervosnetwork/godwoken-web3/pull/488)
+- fix(indexer): Retry when tx receipt not found in [#488](https://github.com/godwokenrises/godwoken-web3/pull/488)
     This PR fixed the issue that the web3 indexer cannot receive the receipt and then failed. After fixing, it will retry for 10 times and wait for ~55s approx, or exit with an error if it still not found.
 
-- fix: `gw_submit_l2transaction` support auto create account tx in [#498](https://github.com/nervosnetwork/godwoken-web3/pull/498)
+- fix: `gw_submit_l2transaction` support auto create account tx in [#498](https://github.com/godwokenrises/godwoken-web3/pull/498)
 
-- Fix log transaction index in [#502](https://github.com/nervosnetwork/godwoken-web3/pull/502)
-    This PR fixed the issue that [`eth_getTransactionReceipt` 's transactionIndex was inconsistent with `log.transactionIndex`](https://github.com/nervosnetwork/godwoken-web3/issues/495). `log.transaction_index` was always zero when indexed after version v1.6.0-rc1. You need to consider re-async database from scratch, or use the provided CLI tool to correct the wrong data. See: https://github.com/nervosnetwork/godwoken-web3/blob/1.6-rc/packages/api-server/cli/README.md
+- Fix log transaction index in [#502](https://github.com/godwokenrises/godwoken-web3/pull/502)
+    This PR fixed the issue that [`eth_getTransactionReceipt` 's transactionIndex was inconsistent with `log.transactionIndex`](https://github.com/godwokenrises/godwoken-web3/issues/495). `log.transaction_index` was always zero when indexed after version v1.6.0-rc1. You need to consider re-async database from scratch, or use the provided CLI tool to correct the wrong data. See: https://github.com/godwokenrises/godwoken-web3/blob/1.6-rc/packages/api-server/cli/README.md
     **To use the provided CLI tool**
     ```
     // Get count, database-url can also read from env
@@ -55,8 +55,8 @@ This PR aimed at fetching and storing transactions & logs in batch, which can be
 
 
 #### Others
-- chore: Add log for auto create account tx in [#481](https://github.com/nervosnetwork/godwoken-web3/pull/481)
-- chore: update gw schemas in [#453](https://github.com/nervosnetwork/godwoken-web3/pull/453)
-- chore: Bump nodemon version in [#471](https://github.com/nervosnetwork/godwoken-web3/pull/471)
-- Add issue templates in [#290](https://github.com/nervosnetwork/godwoken-web3/pull/290)
-- chore: Update comments in [#501](https://github.com/nervosnetwork/godwoken-web3/pull/501) 
+- chore: Add log for auto create account tx in [#481](https://github.com/godwokenrises/godwoken-web3/pull/481)
+- chore: update gw schemas in [#453](https://github.com/godwokenrises/godwoken-web3/pull/453)
+- chore: Bump nodemon version in [#471](https://github.com/godwokenrises/godwoken-web3/pull/471)
+- Add issue templates in [#290](https://github.com/godwokenrises/godwoken-web3/pull/290)
+- chore: Update comments in [#501](https://github.com/godwokenrises/godwoken-web3/pull/501) 

--- a/docs/web3Compatible.md
+++ b/docs/web3Compatible.md
@@ -25,7 +25,7 @@ The `to` member of a Godwoken transaction must be a contract.
 
 **Recommend Workaround**
 
- - *Transfer Value From EOA To EOA*: Use the `transfer function` in [CKB_ERC20_Proxy](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract [combined](https://github.com/nervosnetwork/godwoken-polyjuice/blob/3f1ad5b322/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol#L154) with sUDT_ID = 1 (CKB a.k.a. [pCKB](https://github.com/nervosnetwork/godwoken/blob/develop/docs/life_of_a_polyjuice_transaction.md#pckb)).
+ - *Transfer Value From EOA To EOA*: Use the `transfer function` in [CKB_ERC20_Proxy](https://github.com/godwokenrises/godwoken-polyjuice/blob/3f1ad5b/solidity/erc20/README.md) contract [combined](https://github.com/godwokenrises/godwoken-polyjuice/blob/3f1ad5b322/solidity/erc20/SudtERC20Proxy_UserDefinedDecimals.sol#L154) with sUDT_ID = 1 (CKB a.k.a. [pCKB](https://github.com/godwokenrises/godwoken/blob/develop/docs/life_of_a_polyjuice_transaction.md#pckb)).
 
 ----
 
@@ -52,4 +52,4 @@ Godwoken does not have corresponding "zero address"(0x00000000000000000000000000
 
  - if you are trying use zero address as a black hole to burn ethers, you can use `transfer function` in CKB_ERC20_Proxy to send ethers to zero address. more info can be found on above section `Transfer Value From EOA To EOA`.
 
-For more information on Godwoken Web3 API, visite [godwoken-web3](https://github.com/nervosnetwork/godwoken-web3/tree/compatibility-breaking-changes).
+For more information on Godwoken Web3 API, visite [godwoken-web3](https://github.com/godwokenrises/godwoken-web3/tree/compatibility-breaking-changes).


### PR DESCRIPTION
### Description
We have moved godwoken repos under our new organization: godwokenrises.
Therefor we're changing relevant links in the documentation:
- from "github.com/nervosnetwork/godwoken-xxx" 
- to "github.com/godwokenrises/godwoken-xxx"