### PR TITLE
Feat: disalbe trailing slashes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,7 @@ module.exports = {
   tagline: "Godwoken Docs",
   url: "https://docs.godwoken.io/",
   baseUrl: "/",
+  trailingSlash: false,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
@@ -71,7 +72,7 @@ module.exports = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: 'latest',
+              label: 'Latest',
               path: '/'
             }
           },


### PR DESCRIPTION
By default, Github Pages adds a trailing slash to the path.
So I added a `trailingSlash: false` to the config and hope it can fix the redirecting problem in algolia.