### PR TITLE
Simple fix of articles and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
-# Website
+# Godwoken Docs
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+**Godwoken Docs** is a documentation site designed to help developers of all levels explore the world of Godwoken. 
 
-## Installation
+It's built with various articles about Godwoken, from simple concept explanations and step-by-step tutorials, to deep dives into how Godwoken actually works, all waiting for you to explore.
 
-```console
+To visit online: [Godwoken Docs](https://docs.godwoken.io).
+
+## Issues
+
+We are working hard to improve the reading experience of the website, if you find anything missed from the site, or anything mistaken, even anything you find it's difficult to read, you're more than welcome to open an issue to let us know.
+
+Create an issue: [New Issue](https://github.com/godwokenrises/godwoken-doc/issues/new).
+
+## Development
+
+This website is powered by Docusaurus 2, a modern static website generator. 
+
+You can run the project in local environment with the following commands, and if you have any questions about the configuration, you should be able to find them in Docusaurus' documentation site: [Docusaurus 2](https://docusaurus.io/).
+
+**Install dependencies:**
+```shell
 yarn install
 ```
 
-## Local Development
-
-```console
+**Run in local:**
+```shell
 yarn start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
-
-```console
+**Build:**
+```shell
 yarn build
 ```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-```console
-GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/docs/evm_training/evmTask4.md
+++ b/docs/evm_training/evmTask4.md
@@ -4,6 +4,10 @@ title: 4. Use Force Bridge to Deposit Tokens from Ethereum
 ---
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
+:::caution
+This article is out of date as the Rinkeby testnet has been deprecated.
+We will update relevant articles later, if you like to study on how to claim Goerli tokens and bridge them from Goerli testnet to Godwoken, please visit: [Claim assets on testnet v1](../claimFaucet.md)
+:::
 
 Moving assets between blockchains is an extremely important part of building the cross-chain dApps of the future. Not only do developers need secure infrastructure to build on, but the experience for the end-user must be simple and straightforward.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: "Godwoken Docs",
   tagline: "Godwoken Docs",
-  url: "https://docs.godwoken.io/",
+  url: "https://docs.godwoken.io",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
@@ -26,9 +26,8 @@ module.exports = {
       title: "Godwoken Docs",
       style: "dark",
       logo: {
-        alt: "Nervos",
-        src: "img/favicon.ico",
-        href: "https://godwoken.com",
+        alt: "Godwoken",
+        src: "img/favicon.ico"
       },
       items: [
         {


### PR DESCRIPTION
### Changes
- Refactor `README.md`
- Mark `evm_traning/evmTask4` as outdated
- Return to home page when click on the title instead of going elsewhere
- Remove tailing slash in config's `url`, trying not to generate weird navigations