### PR TITLE
chore: lock `minimatch` to "^3.1.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "trim": "^0.0.3",
     "url-loader": "^4.1.1"
   },
+  "resolutions": {
+    "**/minimatch": "^3.1.2"
+  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,15 +5888,10 @@ minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
 
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@3.0.4, minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
### Description
Using "resolutions" keyword to force the version of `minimatch` to "^3.1.2".
Would it lead us to a wrong path, should we use this keyword?

### Related issues
- close #94