### PR TITLE
chore: replace testnet rpc url

### DIFF
--- a/docs/connectionInfo.md
+++ b/docs/connectionInfo.md
@@ -37,13 +37,13 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 | ITEM            	| Detail                                             	|
 |-----------------	|----------------------------------------------------	|
 | Network Name     	| Godwoken/PolyJuice Testnet                         	|
-| RPC URL         	| https://godwoken-testnet-v1.ckbapp.dev             	|
+| RPC URL         	| https://v1.testnet.godwoken.io/rpc             	|
 | Chain ID        	| 71401                                              	|
 | Currency Symbol 	| pCKB                                                |
 | Block Explorer  	| https://v1.testnet.gwscan.com/                     	|
 |                 	| https://gw-testnet-explorer.nervosdao.community    	|
 | Token Bridge    	| https://testnet.bridge.godwoken.io                 	|
-| WebSocket       	| wss://godwoken-testnet-v1.ckbapp.dev/ws            	|
+| WebSocket       	| wss://v1.testnet.godwoken.io/ws            	|
 | Graph (subgraph)  | https://gw-testnet-graph.nervosdao.community  	    |
 | Graph RPC       	| https://gw-testnet-graph.nervosdao.community/rpc/  	|
 | Graph IPFS      	| https://gw-testnet-graph.nervosdao.community/ipfs/ 	|

--- a/docs/evm_training/evmTask5.md
+++ b/docs/evm_training/evmTask5.md
@@ -33,7 +33,7 @@ Enter the following details.
 
 ```
 Network Name: Godwoken Testnet
-RPC URL: https://godwoken-testnet-v1.ckbapp.dev
+RPC URL: https://v1.testnet.godwoken.io/rpc
 Chain ID: 71401
 Currency Symbol: pCKB
 Block Explorer URL: <Leave Empty>
@@ -122,5 +122,5 @@ async setStoredValue(value: number) {
 ### Potential Errors and Solutions
 
 * You might need to wait for MetaMask confirmation that your transaction has been included in a block before interacting with the contract. It can take about a minute.
-* If you get a CORS error in your web browser's console, try searching your code for a Godwoken RPC URL that is **not** using `https`. Change any instances of `http://godwoken-testnet-v1.ckbapp.dev` to `https://godwoken-testnet-v1.ckbapp.dev`.
+* If you get a CORS error in your web browser's console, try searching your code for a Godwoken RPC URL that is **not** using `https`. Change any instances of `http://v1.testnet.godwoken.io/rpc` to `https://v1.testnet.godwoken.io/rpc`.
 * There are a number of small differences that can potentially impact your application and cause problems if you're unaware of them. A list of these differences can be found [here](https://github.com/godwokenrises/godwoken-polyjuice/blob/main/docs/EVM-compatible.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,13 +23,13 @@ Developers who want to connect to the Godwoken chain can do so via Metamask wall
 
 Here are the credentials that you will need:
 
-| ITEM               | Testnet                                | Mainnet                            |
-| ------------------ | :------------------------------------- | :--------------------------------- |
-| NETWORK NAME       | Godwoken/PolyJuice Testnet             | Godwoken/PolyJuice Mainnet         |
-| New RPC URL        | https://godwoken-testnet-v1.ckbapp.dev | https://v1.mainnet.godwoken.io/rpc |
-| Chain ID           | 71401                                  | 71402                              |
-| Currency Symbol    | pCKB                                   | pCKB                               |
-| Block Explorer URL | https://v1.testnet.gwscan.com/         | https://v1.gwscan.com/             |
+| ITEM               | Testnet                             | Mainnet                            |
+| ------------------ |:------------------------------------| :--------------------------------- |
+| NETWORK NAME       | Godwoken/PolyJuice Testnet          | Godwoken/PolyJuice Mainnet         |
+| New RPC URL        | https://v1.testnet.godwoken.io/rpc  | https://v1.mainnet.godwoken.io/rpc |
+| Chain ID           | 71401                               | 71402                              |
+| Currency Symbol    | pCKB                                | pCKB                               |
+| Block Explorer URL | https://v1.testnet.gwscan.com/      | https://v1.gwscan.com/             |
 
 Below is a visual guide on how to connect Metamask to Godwoken:
 


### PR DESCRIPTION
Godwoken has a new Testnet RPC url, replacing it:
- `https://godwoken-testnet-v1.ckbapp.dev` -> `https://v1.testnet.godwoken.io/rpc`
- `wss://godwoken-testnet-v1.ckbapp.dev` -> `wss://v1.testnet.godwoken.io/ws`