### PR TITLE
chore(build): add vercel.json to control trailing slash behaviour

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "cleanUrls": true,
+  "trailingSlash": false
+}


### PR DESCRIPTION
We need a `vercel.json` to configure Vercel's proxy behaviour, otherwise our crawler won't work properly.
I cannot find a detailed tutorial on WHERE to put this file, so I just put it in the root directory.